### PR TITLE
Add Folia support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ repositories {
     maven {
         url = uri('https://hub.spigotmc.org/nexus/content/repositories/snapshots/')
     }
+    
+    maven {
+        url = uri('https://repo.papermc.io/repository/maven-public/')
+    }
 
     maven { url 'https://jitpack.io' }
 
@@ -26,7 +30,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 
     compileOnly("org.bstats:bstats-bukkit:3.0.1")
-    compileOnly 'org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT'
+    compileOnly 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7.1'
     compileOnly 'me.clip:placeholderapi:2.11.5'
     compileOnly files('libraries/tebex-bukkit-2.0.0.jar')

--- a/src/main/java/org/metadevs/buycraftapi/BuyCraftAPI.java
+++ b/src/main/java/org/metadevs/buycraftapi/BuyCraftAPI.java
@@ -114,11 +114,10 @@ public class BuyCraftAPI extends PlaceholderExpansion implements Taskable, Confi
 
     @Override
     public void start() {
-        new Tasks(this, getPlaceholderAPI());
-
         request = new Request(provider.getKey(), this);
-
         query = new Query(this);
+        
+        new Tasks(this, getPlaceholderAPI());
 
         int pluginId = 10173;
         final Metrics metrics = new Metrics(getPlaceholderAPI(), pluginId);

--- a/src/main/java/org/metadevs/buycraftapi/tasks/Tasks.java
+++ b/src/main/java/org/metadevs/buycraftapi/tasks/Tasks.java
@@ -2,7 +2,6 @@ package org.metadevs.buycraftapi.tasks;
 
 import org.metadevs.buycraftapi.BuyCraftAPI;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.Bukkit;
 import java.util.concurrent.TimeUnit;
 
@@ -17,7 +16,7 @@ public class Tasks {
         loadAPITask();
     }
 
-    private static boolean checkFolia() {
+    private static boolean isFolia() {
         try {
             Class.forName("io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler");
             return true;
@@ -54,61 +53,39 @@ public class Tasks {
             });
         };
 
-        boolean isFolia = checkFolia();
-        
-        if (isFolia) {
-            try {
-                Class<?> foliaAsyncScheduler = Class.forName("io.papermc.paper.threadedregions.scheduler.AsyncScheduler");
-                Object asyncScheduler = Bukkit.getServer().getClass().getMethod("getAsyncScheduler").invoke(Bukkit.getServer());
-                Class<?> scheduledTaskClass = Class.forName("io.papermc.paper.threadedregions.scheduler.ScheduledTask");
-                Class<?> consumerClass = Class.forName("java.util.function.Consumer");
-                Object taskConsumer = java.lang.reflect.Proxy.newProxyInstance(
-                    consumerClass.getClassLoader(),
-                    new Class[]{consumerClass},
-                    (proxy, method, args) -> {
-                        if (method.getName().equals("accept")) {
-                            Object scheduledTask = args[0];
-                            if(!buyCraftAPI.isRegistered()) {
-                                scheduledTask.getClass().getMethod("cancel").invoke(scheduledTask);
-                                return null;
-                            }
-                            task.run();
-                        }
-                        return null;
-                    }
-                );
-                
-                foliaAsyncScheduler.getMethod("runAtFixedRate", Plugin.class, consumerClass, long.class, long.class, TimeUnit.class)
-                    .invoke(asyncScheduler, placeholderapi, taskConsumer, 0L, 1L, TimeUnit.HOURS);
-                    
-            } catch (Exception e) {
-                buyCraftAPI.getLogger().severe("Failed to schedule task on Folia, falling back to legacy scheduler: " + e.getMessage());
-                fallbackToLegacyScheduler(task);
-            }
+        if (isFolia()) {
+            scheduleFoliaTask(task);
         } else {
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    if(!buyCraftAPI.isRegistered()) {
-                        cancel();
-                        return;
+            Bukkit.getScheduler().runTaskTimerAsynchronously(placeholderapi, task, 0L, 20L * 60L * 60L);
+        }
+    }
+
+    private void scheduleFoliaTask(Runnable task) {
+        try {
+            Object server = Bukkit.getServer();
+            Object asyncScheduler = server.getClass().getMethod("getAsyncScheduler").invoke(server);
+            java.util.function.Consumer<Object> taskConsumer = scheduledTask -> {
+                if(!buyCraftAPI.isRegistered()) {
+                    try {
+                        scheduledTask.getClass().getMethod("cancel").invoke(scheduledTask);
+                    } catch (Exception e) {
+                        buyCraftAPI.getLogger().warning("Failed to cancel scheduled task: " + e.getMessage());
                     }
-                    task.run();
+                    return;
                 }
-            }.runTaskTimerAsynchronously(placeholderapi, 0L, 20L * 60L * 60L);
+                task.run();
+            };
+            asyncScheduler.getClass()
+                .getMethod("runAtFixedRate", Plugin.class, java.util.function.Consumer.class, long.class, long.class, TimeUnit.class)
+                .invoke(asyncScheduler, placeholderapi, taskConsumer, 0L, 1L, TimeUnit.HOURS);
+                
+        } catch (Exception e) {
+            buyCraftAPI.getLogger().severe("Failed to schedule task on Folia, falling back to legacy scheduler: " + e.getMessage());
+            fallbackToLegacyScheduler(task);
         }
     }
 
     private void fallbackToLegacyScheduler(Runnable task) {
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                if(!buyCraftAPI.isRegistered()) {
-                    cancel();
-                    return;
-                }
-                task.run();
-            }
-        }.runTaskTimerAsynchronously(placeholderapi, 0L, 20L * 60L * 60L);
+        Bukkit.getScheduler().runTaskTimerAsynchronously(placeholderapi, task, 0L, 20L * 60L * 60L);
     }
 }

--- a/src/main/java/org/metadevs/buycraftapi/tasks/Tasks.java
+++ b/src/main/java/org/metadevs/buycraftapi/tasks/Tasks.java
@@ -1,7 +1,6 @@
 package org.metadevs.buycraftapi.tasks;
 
 import org.metadevs.buycraftapi.BuyCraftAPI;
-import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.Bukkit;
@@ -11,7 +10,6 @@ public class Tasks {
 
     private final BuyCraftAPI buyCraftAPI;
     private final Plugin placeholderapi;
-    private static final boolean IS_FOLIA = checkFolia();
 
     public Tasks(BuyCraftAPI buyCraftAPI, Plugin placeholderapi) {
         this.buyCraftAPI = buyCraftAPI;
@@ -35,6 +33,11 @@ public class Tasks {
             if(!buyCraftAPI.isRegistered()) {
                 return;
             }
+            
+            if (buyCraftAPI.getQuery() == null) {
+                buyCraftAPI.getLogger().warning("Query not initialized yet, skipping payment load");
+                return;
+            }
 
             long start = System.currentTimeMillis();
             buyCraftAPI.getLogger().info("Loading payments...");
@@ -51,7 +54,9 @@ public class Tasks {
             });
         };
 
-        if (IS_FOLIA) {
+        boolean isFolia = checkFolia();
+        
+        if (isFolia) {
             try {
                 Class<?> foliaAsyncScheduler = Class.forName("io.papermc.paper.threadedregions.scheduler.AsyncScheduler");
                 Object asyncScheduler = Bukkit.getServer().getClass().getMethod("getAsyncScheduler").invoke(Bukkit.getServer());

--- a/src/main/java/org/metadevs/buycraftapi/tasks/Tasks.java
+++ b/src/main/java/org/metadevs/buycraftapi/tasks/Tasks.java
@@ -4,12 +4,14 @@ import org.metadevs.buycraftapi.BuyCraftAPI;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.Bukkit;
+import java.util.concurrent.TimeUnit;
 
 public class Tasks {
 
     private final BuyCraftAPI buyCraftAPI;
     private final Plugin placeholderapi;
-
+    private static final boolean IS_FOLIA = checkFolia();
 
     public Tasks(BuyCraftAPI buyCraftAPI, Plugin placeholderapi) {
         this.buyCraftAPI = buyCraftAPI;
@@ -17,34 +19,91 @@ public class Tasks {
         loadAPITask();
     }
 
+    private static boolean checkFolia() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
 
     public void loadAPITask() {
         buyCraftAPI.getLogger().info("Loading API Tasks...");
+        
+        Runnable task = () -> {
+            if(!buyCraftAPI.isRegistered()) {
+                return;
+            }
+
+            long start = System.currentTimeMillis();
+            buyCraftAPI.getLogger().info("Loading payments...");
+            buyCraftAPI.getQuery().loadPayments().thenAccept(success -> {
+                if (success) {
+                    long end = System.currentTimeMillis();
+                    buyCraftAPI.getLogger().info("Successfully loaded payments in " + (end - start) + "ms");
+                } else {
+                    buyCraftAPI.getLogger().info("Failed to load payments");
+                }
+            }).exceptionally(throwable -> {
+                buyCraftAPI.getLogger().log(java.util.logging.Level.SEVERE, "Failed to load payments", throwable);
+                return null;
+            });
+        };
+
+        if (IS_FOLIA) {
+            try {
+                Class<?> foliaAsyncScheduler = Class.forName("io.papermc.paper.threadedregions.scheduler.AsyncScheduler");
+                Object asyncScheduler = Bukkit.getServer().getClass().getMethod("getAsyncScheduler").invoke(Bukkit.getServer());
+                Class<?> scheduledTaskClass = Class.forName("io.papermc.paper.threadedregions.scheduler.ScheduledTask");
+                Class<?> consumerClass = Class.forName("java.util.function.Consumer");
+                Object taskConsumer = java.lang.reflect.Proxy.newProxyInstance(
+                    consumerClass.getClassLoader(),
+                    new Class[]{consumerClass},
+                    (proxy, method, args) -> {
+                        if (method.getName().equals("accept")) {
+                            Object scheduledTask = args[0];
+                            if(!buyCraftAPI.isRegistered()) {
+                                scheduledTask.getClass().getMethod("cancel").invoke(scheduledTask);
+                                return null;
+                            }
+                            task.run();
+                        }
+                        return null;
+                    }
+                );
+                
+                foliaAsyncScheduler.getMethod("runAtFixedRate", Plugin.class, consumerClass, long.class, long.class, TimeUnit.class)
+                    .invoke(asyncScheduler, placeholderapi, taskConsumer, 0L, 1L, TimeUnit.HOURS);
+                    
+            } catch (Exception e) {
+                buyCraftAPI.getLogger().severe("Failed to schedule task on Folia, falling back to legacy scheduler: " + e.getMessage());
+                fallbackToLegacyScheduler(task);
+            }
+        } else {
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    if(!buyCraftAPI.isRegistered()) {
+                        cancel();
+                        return;
+                    }
+                    task.run();
+                }
+            }.runTaskTimerAsynchronously(placeholderapi, 0L, 20L * 60L * 60L);
+        }
+    }
+
+    private void fallbackToLegacyScheduler(Runnable task) {
         new BukkitRunnable() {
             @Override
             public void run() {
-
                 if(!buyCraftAPI.isRegistered()) {
                     cancel();
                     return;
                 }
-
-                long start = System.currentTimeMillis();
-                buyCraftAPI.getLogger().info("Loading payments...");
-                buyCraftAPI.getQuery().loadPayments().thenAccept(success -> {
-                    if (success) {
-                        long end = System.currentTimeMillis();
-                        buyCraftAPI.getLogger().info("Successfully loaded payments in " + (end - start) + "ms");
-                    } else {
-                        buyCraftAPI.getLogger().info("Failed to load payments");
-                    }
-                }).exceptionally(throwable -> {
-                    buyCraftAPI.getLogger().log(java.util.logging.Level.SEVERE, "Failed to load payments", throwable);
-                    return null;
-                });
+                task.run();
             }
-        }.runTaskTimerAsynchronously(placeholderapi, 0L, 20 * 60 * 60);
+        }.runTaskTimerAsynchronously(placeholderapi, 0L, 20L * 60L * 60L);
     }
-
-
 }


### PR DESCRIPTION
This PR adds Folia support. 

• Added Folia async scheduler support with automatic detection and fallback to Bukkit scheduler
• Fixed NullPointerException in Tasks by reordering initialization - Query is now created before Tasks (Ran into the same issue as #7 )
• Added null check in Tasks
• No breaking changes, backward compatible with existing servers
• Builds successfully and resolves the async task exception (gradle wrapper seems to have issues though, had to create a new one locally)

Tested on both Paper & Folia. Added this support due to [this PR](https://github.com/tebexio/Tebex-Minecraft/pull/84) which is to be released in the next version.